### PR TITLE
Add release instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ jobs:
         filename: 'release.zip'
         exclusions: '*.git* /*node_modules/* .editorconfig'
 ```
+You can add this job to release the zipped file to GitHub(change the artifact file to the release filename):
+```
+- name: Upload Release
+    uses: ncipollo/release-action@v1
+    with:
+        artifacts: "release.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ## Arguments
 | Argument | Description | Default |


### PR DESCRIPTION
The repository has "release" in the name and this is the first action that comes up when searching "github zip and release" on Google, so  I thought it was appropriate to add instructions to actually release the zip created by this action to the instructions.

The code is from [here](https://github.com/TheDoctor0/zip-release/issues/8#issuecomment-739504751)