### PR TITLE
fix exclusions for tar mode, and increase readability in code and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ GitHub action that can be used to create release archive using zip or tar.
 
 ## Usage
 An example workflow config:
-```
+```yaml
 name: Create Archive
 on: [push]
 jobs:
@@ -18,21 +18,50 @@ jobs:
         exclusions: '*.git* /*node_modules/* .editorconfig'
 ```
 
-You can also add this action to attach created archive file to the latest release:
-```
+The generated archive will be placed as specified by `directory` and `filename`.
+If you want to attach it to the latest release use another action like [`ncipollo/release-action`](https://github.com/ncipollo/release-action):
+```yaml
 - name: Upload Release
-    uses: ncipollo/release-action@v1
-    with:
-        artifacts: "release.zip"
-        token: ${{ secrets.GITHUB_TOKEN }}
+  uses: ncipollo/release-action@v1
+  with:
+    artifacts: "release.zip"
+    token: ${{ secrets.GITHUB_TOKEN }}
 ```
-More about `ncipollo/release-action` can be found [here](https://github.com/ncipollo/release-action).
 
 ## Arguments
-| Argument | Description | Default |
-|---|---|---|
-| filename | Filename for archive | release.zip |
-| path | Base path for archive files | . |
-| directory | Working directory before zipping | . |
-| exclusions | List of excluded files / directories | |
-| type | Tool to use for archiving (zip / tar) | zip |
+
+### `filename`
+Default: `release.zip`
+
+The filename for the generated archive, relative to `directory`.
+
+If you use `type: tar` it's recommended to set the filename to a `tar.gz` (the tarball is always gzip compressed).
+
+### `path`
+Default: `.`
+
+The path to the files or directory that should be archived, relative to `directory`
+
+### `directory`
+Default: `.`
+
+The working directory where the zip or tar actually runs.
+
+### `exclusions`
+Default: none
+
+List of excluded files or directories.
+
+Please note: this handles slightly differently, depending on if you use `type: zip` or `type: tar`.
+
+ZIP requires you to specify wildcards or full filenames.
+
+TAR allows you to specify only the filename, no matter if it's in a subdirectory.
+
+### `type`
+Default: `zip`
+
+Either `zip` or `tar`.
+
+Defines if either a ZIP-file is created, or a tar archive (the latter gzipped).
+

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,3 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.filename }}
-    - ${{ inputs.path }}
-    - ${{ inputs.directory }}
-    - ${{ inputs.exclusions }}
-    - ${{ inputs.type }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,31 +3,31 @@
 # Create archive or exit if command fails
 set -eu
 
-printf "\n📦 Creating %s archive...\n" "$5"
+printf "\n📦 Creating %s archive...\n" "$INPUT_TYPE"
 
-if [ "$3" != "." ]
+if [ "$INPUT_DIRECTORY" != "." ]
 then
-  cd $3
+  cd $INPUT_DIRECTORY
 fi
 
-if [ "$5" = "zip" ]
+if [ "$INPUT_TYPE" = "zip" ]
 then
-  if [ -z "$4" ]
+  if [ -z "$INPUT_EXCLUSIONS" ]
   then
-    zip -r $1 $2 || { printf "\n⛔ Unable to create %s archive.\n" "$5"; exit 1;  }
+    zip -r $INPUT_FILENAME $INPUT_PATH || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
   else
-    zip -r $1 $2 -x $4 || { printf "\n⛔ Unable to create %s archive.\n" "$5"; exit 1;  }
+    zip -r $INPUT_FILENAME $INPUT_PATH -x $INPUT_EXCLUSIONS || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
   fi
-elif [ "$5" = "tar" ]
+elif [ "$INPUT_TYPE" = "tar" ]
 then
-  if [ -z "$4" ]
+  if [ -z "$INPUT_EXCLUSIONS" ]
   then
-    tar -zcvf $1 $2 || { printf "\n⛔ Unable to create %s archive.\n" "$5"; exit 1;  }
+    tar -zcvf $INPUT_FILENAME $INPUT_PATH || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
   else
-    tar -zcvf $1 --exclude=$4 $2 || { printf "\n⛔ Unable to create %s archive.\n" "$5"; exit 1;  }
+    tar -zcvf $INPUT_FILENAME --exclude=$INPUT_EXCLUSIONS $INPUT_PATH || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
   fi
 else
   printf "\n⛔ Invalid archiving tool.\n"; exit 1;
 fi
 
-printf "\n✔ Successfully created %s archive.\n" "$5"
+printf "\n✔ Successfully created %s archive.\n" "$INPUT_TYPE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ then
   then
     tar -zcvf $1 $2 || { printf "\n⛔ Unable to create %s archive.\n" "$5"; exit 1;  }
   else
-    tar -zcvf $1 $2 --exclude=$4 || { printf "\n⛔ Unable to create %s archive.\n" "$5"; exit 1;  }
+    tar -zcvf $1 --exclude=$4 $2 || { printf "\n⛔ Unable to create %s archive.\n" "$5"; exit 1;  }
   fi
 else
   printf "\n⛔ Invalid archiving tool.\n"; exit 1;


### PR DESCRIPTION
I used this action today, and hit a few snags, that ultimately required me to resort to reading the code and checking the man pages or zip and tar.

As I'd like other newcomers to Github Actions to have a better time, I thought I'd fix the issues I had (mainly the tar exclusion) and rewrite the script so reading it is much more obvious and doesn't require cross referencing between the `action.yaml` and `entrypoint.sh`.

Lastly I rewrote the README to have space for explanations that should make it easy for everyone new to bundling files, and pointing out the differences between tar and zip.