### PR TITLE
double quotes around filenames, paths

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ printf "\n📦 Creating %s archive...\n" "$INPUT_TYPE"
 
 if [ "$INPUT_DIRECTORY" != "." ] 
 then
-  cd $INPUT_DIRECTORY
+  cd "$INPUT_DIRECTORY"
 fi
 
 if [ "$INPUT_TYPE" = "zip" ] 
@@ -16,7 +16,7 @@ then
   then
     if [ -z "$INPUT_EXCLUSIONS" ] 
     then
-      7z a -tzip $INPUT_FILENAME $INPUT_PATH $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
+      7z a -tzip "$INPUT_FILENAME" "$INPUT_PATH" $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
     else
       EXCLUSIONS=''
 
@@ -32,21 +32,21 @@ then
         EXCLUSIONS+=$EXCLUSION
       done
 
-      7z a -tzip $INPUT_FILENAME $INPUT_PATH $EXCLUSIONS $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
+      7z a -tzip "$INPUT_FILENAME" "$INPUT_PATH" $EXCLUSIONS $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
     fi
   else
-    if [ -z "$INPUT_EXCLUSIONS" ] 
+    if [ -z "$INPUT_EXCLUSIONS" ]
     then
-      zip -r $INPUT_FILENAME $INPUT_PATH $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
+      zip -r "$INPUT_FILENAME" "$INPUT_PATH" $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
     else
-      zip -r $INPUT_FILENAME $INPUT_PATH -x $INPUT_EXCLUSIONS $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
+      zip -r "$INPUT_FILENAME" "$INPUT_PATH" -x $INPUT_EXCLUSIONS $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
     fi
   fi
 elif [ "$INPUT_TYPE" = "tar" ] || [ "$INPUT_TYPE" = "tar.gz" ] 
 then
   if [ -z "$INPUT_EXCLUSIONS" ] 
   then
-    tar -zcvf $INPUT_FILENAME $INPUT_PATH $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
+    tar -zcvf "$INPUT_FILENAME" "$INPUT_PATH" $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
   else
     EXCLUSIONS=''
 
@@ -56,7 +56,7 @@ then
       EXCLUSIONS+=$EXCLUSION
     done
 
-    tar $EXCLUSIONS -zcvf $INPUT_FILENAME $INPUT_PATH $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
+    tar $EXCLUSIONS -zcvf "$INPUT_FILENAME" "$INPUT_PATH" $INPUT_CUSTOM || { printf "\n⛔ Unable to create %s archive.\n" "$INPUT_TYPE"; exit 1;  }
   fi
 else
   printf "\n⛔ Invalid archiving tool.\n"; exit 1;


### PR DESCRIPTION
Added double quotes around file name / directory / path arguments when passing to tar/zip command.
fixes #46 